### PR TITLE
Adds non-cheating haskell version

### DIFF
--- a/forest.hs
+++ b/forest.hs
@@ -1,41 +1,53 @@
 module Main where
 
-import qualified Data.Set as S
-import System.Environment
+import           Data.List
+import           System.Environment
 
 data Forest = Forest
-  { goats :: !Int
+  { goats  :: !Int
   , wolves :: !Int
-  , lions :: !Int
-} deriving (Show, Ord, Eq)
+  , lions  :: !Int
+  } deriving (Show, Ord, Eq)
 
 isStable :: Forest -> Bool
 isStable (Forest 0 0 _) = True
 isStable (Forest 0 _ 0) = True
 isStable (Forest _ 0 0) = True
-isStable _ = False
+isStable _              = False
 
 isValid :: Forest -> Bool
 isValid (Forest g w l) = g >= 0 && w >= 0 && l >= 0
 
-mutate :: S.Set Forest -> S.Set Forest
-mutate = S.filter isValid . S.unions . f
-  where f set = [S.map lionEats set, S.map wolfEats set, S.map goatEats set]
-        lionEats (Forest g w l) = Forest (g-1) (w-1) (l+1)
-        wolfEats (Forest g w l) = Forest (g-1) (w+1) (l-1)
-        goatEats (Forest g w l) = Forest (g+1) (w-1) (l-1)
-
-solve :: Forest -> S.Set Forest
-solve = solve' . S.singleton
+-- removes adjacent identical elements
+dedup :: [Forest] -> [Forest]
+dedup = go $ Forest 0 0 0
   where
-  solve' xs | cond xs = solve' $ mutate xs
-            | otherwise = S.filter isStable xs
-  cond set | S.null set = False
-           | otherwise = S.null . S.filter isStable $ set
+    go s (x:xs)
+      | x == s = go s xs
+      | otherwise = x : go x xs
+    go _ _ = []
+
+mutate :: [Forest] -> [Forest]
+mutate xs = dedup . sort . filter isValid . concatMap f $ xs
+  where
+    f (Forest g w l) =
+      [ Forest (g - 1) (w - 1) (l + 1)
+      , Forest (g - 1) (w + 1) (l - 1)
+      , Forest (g + 1) (w - 1) (l - 1)
+      ]
+
+solve :: Forest -> [Forest]
+solve x = solve' [x]
+  where
+    solve' xs
+      | cond xs = solve' $ mutate xs
+      | otherwise = filter isStable xs
+    cond [] = False
+    cond xs = null . filter isStable $ xs
 
 main :: IO ()
 main = do
   [g, w, l] <- fmap (map read) $ getArgs
-  let initial = (Forest g w l)
+  let initial = Forest g w l
   print initial
   print $ solve initial


### PR DESCRIPTION
Attempt 2 as I messed with the git history too much. Had a day off today so figured I'd give this another shot.

Re: #5 this is a non cheating version that takes slightly longer than the previous version but does not cheat and uses native lists. Takes about 8 seconds on the same processor that took about 5 before. Also tried to get it working with Data.Vector but sorting seems to take far too long, perhaps because of unboxing the records?

Edit: Seems a slower on the CI than expected. Probably needs more investigation but off on Holiday soon.